### PR TITLE
Refactor ResolveListAdapter

### DIFF
--- a/app/src/main/java/com/tasomaniac/openwith/AppComponent.java
+++ b/app/src/main/java/com/tasomaniac/openwith/AppComponent.java
@@ -6,7 +6,6 @@ import com.tasomaniac.openwith.data.Analytics;
 import com.tasomaniac.openwith.homescreen.AddToHomeScreenDialogFragment;
 import com.tasomaniac.openwith.intro.IntroActivity;
 import com.tasomaniac.openwith.preferred.PreferredAppsActivity;
-import com.tasomaniac.openwith.resolver.ResolveListAdapter;
 import com.tasomaniac.openwith.settings.SettingsActivity;
 import com.tasomaniac.openwith.settings.SettingsFragment;
 
@@ -39,5 +38,4 @@ public interface AppComponent {
 
     void inject(AddToHomeScreenDialogFragment fragment);
 
-    void inject(ResolveListAdapter adapter);
 }

--- a/app/src/main/java/com/tasomaniac/openwith/ShareToOpenWith.java
+++ b/app/src/main/java/com/tasomaniac/openwith/ShareToOpenWith.java
@@ -30,30 +30,6 @@ import static com.tasomaniac.openwith.util.Urls.fixUrls;
 
 public class ShareToOpenWith extends Activity {
 
-    private static final String[] PRIORITY_PACKAGES = new String[]{
-            "com.whatsapp",
-            "com.twitter.android",
-            "com.facebook.katana",
-            "com.facebook.orca",
-            "com.google.android.youtube",
-            "com.google.android.gm",
-            "com.google.android.talk",
-            "com.google.android.apps.plus",
-            "com.google.android.apps.photos",
-            "com.pandora.android",
-            "com.instagram.android",
-            "com.linkedin.android",
-            "com.spotify.music",
-            "com.pinterest",
-            "com.medium.reader",
-            "com.ubercab",
-            "com.meetup",
-            "com.tumblr",
-            "com.badoo.mobile",
-            "tv.periscope.android",
-            "com.skype.raider"
-    };
-
     public static final String EXTRA_FROM_DIRECT_SHARE = "EXTRA_FROM_DIRECT_SHARE";
 
     private static boolean isFromDirectShare(Intent intent) {
@@ -129,7 +105,6 @@ public class ShareToOpenWith extends Activity {
 
         startActivity(intentToHandle
                               .putExtra(ShareCompat.EXTRA_CALLING_PACKAGE, callerPackage)
-                              .putExtra(ResolverActivity.EXTRA_PRIORITY_PACKAGES, PRIORITY_PACKAGES)
                               .putExtra(ResolverActivity.EXTRA_LAST_CHOSEN_COMPONENT, lastChosenComponent)
                               .setClass(this, ResolverActivity.class));
 

--- a/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsActivity.java
+++ b/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsActivity.java
@@ -67,7 +67,7 @@ public class PreferredAppsActivity extends AppCompatActivity
                 DividerItemDecoration.VERTICAL_LIST
         ));
         recyclerView.setItemAnimator(new SlideInRightAnimator());
-        adapter = new PreferredAppsAdapter(this, iconLoader, new ArrayList<DisplayResolveInfo>());
+        adapter = new PreferredAppsAdapter(iconLoader, new ArrayList<DisplayResolveInfo>());
         adapter.setItemClickListener(this);
         recyclerView.setAdapter(adapter);
 

--- a/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsActivity.java
+++ b/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsActivity.java
@@ -14,6 +14,7 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 
+import com.tasomaniac.openwith.IconLoader;
 import com.tasomaniac.openwith.R;
 import com.tasomaniac.openwith.data.Analytics;
 import com.tasomaniac.openwith.data.Injector;
@@ -41,6 +42,7 @@ public class PreferredAppsActivity extends AppCompatActivity
         AppRemoveDialogFragment.Callbacks {
 
     @Inject Analytics analytics;
+    @Inject IconLoader iconLoader;
 
     @BindView(R.id.recycler_view) RecyclerView recyclerView;
 
@@ -65,7 +67,7 @@ public class PreferredAppsActivity extends AppCompatActivity
                 DividerItemDecoration.VERTICAL_LIST
         ));
         recyclerView.setItemAnimator(new SlideInRightAnimator());
-        adapter = new PreferredAppsAdapter(this, new ArrayList<DisplayResolveInfo>());
+        adapter = new PreferredAppsAdapter(this, iconLoader, new ArrayList<DisplayResolveInfo>());
         adapter.setItemClickListener(this);
         recyclerView.setAdapter(adapter);
 

--- a/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsAdapter.java
+++ b/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsAdapter.java
@@ -18,7 +18,6 @@ class PreferredAppsAdapter extends ResolveListAdapter {
         super(context, iconLoader);
 
         mList.addAll(apps);
-        mShowExtended = true;
     }
 
     void remove(DisplayResolveInfo item) {
@@ -51,5 +50,10 @@ class PreferredAppsAdapter extends ResolveListAdapter {
         final ViewHolder viewHolder = super.onCreateViewHolder(viewGroup, i);
         viewHolder.itemView.setMinimumHeight(Utils.dpToPx(viewGroup.getResources(), 72));
         return viewHolder;
+    }
+
+    @Override
+    protected boolean shouldShowExtended() {
+        return true;
     }
 }

--- a/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsAdapter.java
+++ b/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsAdapter.java
@@ -31,10 +31,6 @@ class PreferredAppsAdapter extends ResolveListAdapter {
     }
 
     @Override
-    protected void rebuildList() {
-    }
-
-    @Override
     protected ViewHolder onCreateHeaderViewHolder(ViewGroup parent, int viewType) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());
         return new ViewHolder(inflater.inflate(R.layout.preferred_header, parent, false));

--- a/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsAdapter.java
+++ b/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsAdapter.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
+import com.tasomaniac.openwith.IconLoader;
 import com.tasomaniac.openwith.R;
 import com.tasomaniac.openwith.resolver.DisplayResolveInfo;
 import com.tasomaniac.openwith.resolver.ResolveListAdapter;
@@ -13,8 +14,8 @@ import java.util.List;
 
 class PreferredAppsAdapter extends ResolveListAdapter {
 
-    PreferredAppsAdapter(Context context, List<DisplayResolveInfo> apps) {
-        super(context);
+    PreferredAppsAdapter(Context context, IconLoader iconLoader, List<DisplayResolveInfo> apps) {
+        super(context, iconLoader);
 
         mList.addAll(apps);
         mShowExtended = true;

--- a/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsAdapter.java
+++ b/app/src/main/java/com/tasomaniac/openwith/preferred/PreferredAppsAdapter.java
@@ -1,6 +1,5 @@
 package com.tasomaniac.openwith.preferred;
 
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
@@ -14,8 +13,8 @@ import java.util.List;
 
 class PreferredAppsAdapter extends ResolveListAdapter {
 
-    PreferredAppsAdapter(Context context, IconLoader iconLoader, List<DisplayResolveInfo> apps) {
-        super(context, iconLoader);
+    PreferredAppsAdapter(IconLoader iconLoader, List<DisplayResolveInfo> apps) {
+        super(iconLoader);
 
         mList.addAll(apps);
     }

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/IntentResolver.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/IntentResolver.java
@@ -1,0 +1,232 @@
+package com.tasomaniac.openwith.resolver;
+
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+import android.support.v4.app.ShareCompat;
+import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import dagger.Lazy;
+
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.M;
+import static com.tasomaniac.openwith.resolver.ResolverActivity.EXTRA_LAST_CHOSEN_COMPONENT;
+
+public class IntentResolver {
+
+    private static final Intent BROWSER_INTENT;
+
+    static {
+        BROWSER_INTENT = new Intent();
+        BROWSER_INTENT.setAction(Intent.ACTION_VIEW);
+        BROWSER_INTENT.addCategory(Intent.CATEGORY_BROWSABLE);
+        BROWSER_INTENT.setData(Uri.parse("http:"));
+    }
+
+    private final PackageManager packageManager;
+    private final Lazy<ResolverComparator> resolverComparator;
+    private final Intent sourceIntent;
+    private final String callerPackage;
+    private final ComponentName lastChosenComponent;
+
+    private boolean mShowExtended;
+    private int lastChosenPosition = RecyclerView.NO_POSITION;
+
+    public IntentResolver(PackageManager packageManager, Lazy<ResolverComparator> resolverComparator, Intent sourceIntent) {
+        this.packageManager = packageManager;
+        this.resolverComparator = resolverComparator;
+        this.sourceIntent = sourceIntent;
+        this.callerPackage = sourceIntent.getStringExtra(ShareCompat.EXTRA_CALLING_PACKAGE);
+        this.lastChosenComponent = sourceIntent.getParcelableExtra(EXTRA_LAST_CHOSEN_COMPONENT);
+    }
+
+    public int lastChosenPosition() {
+        return lastChosenPosition;
+    }
+
+    public boolean shouldShowExtended() {
+        return mShowExtended;
+    }
+
+    public List<DisplayResolveInfo> rebuildList() {
+        List<DisplayResolveInfo> resolved = new ArrayList<>();
+        int flag;
+        if (SDK_INT >= M) {
+            flag = PackageManager.MATCH_ALL;
+        } else {
+            flag = PackageManager.MATCH_DEFAULT_ONLY;
+        }
+        flag = flag | PackageManager.GET_RESOLVED_FILTER;
+
+        List<ResolveInfo> currentResolveList = new ArrayList<>();
+        currentResolveList.addAll(packageManager.queryIntentActivities(sourceIntent, flag));
+
+        if (SDK_INT >= M) {
+            addBrowsersToList(currentResolveList, flag);
+        }
+
+        //Remove the components from the caller
+        if (!TextUtils.isEmpty(callerPackage)) {
+            removePackageFromList(callerPackage, currentResolveList);
+        }
+
+        int N;
+        if ((N = currentResolveList.size()) > 0) {
+            // Only display the first matches that are either of equal
+            // priority or have asked to be default options.
+            ResolveInfo r0 = currentResolveList.get(0);
+            for (int i = 1; i < N; i++) {
+                ResolveInfo ri = currentResolveList.get(i);
+
+                if (r0.priority != ri.priority ||
+                        r0.isDefault != ri.isDefault) {
+                    while (i < N) {
+                        currentResolveList.remove(i);
+                        N--;
+                    }
+                }
+            }
+
+            //If there is no left, return
+            if (N <= 0) {
+                return resolved;
+            }
+
+            if (N > 1) {
+                Collections.sort(currentResolveList, resolverComparator.get());
+            }
+
+            // Check for applications with same name and use application name or
+            // package name if necessary
+            r0 = currentResolveList.get(0);
+            int start = 0;
+            CharSequence r0Label = r0.loadLabel(packageManager);
+            mShowExtended = false;
+            for (int i = 1; i < N; i++) {
+                if (r0Label == null) {
+                    r0Label = r0.activityInfo.packageName;
+                }
+                ResolveInfo ri = currentResolveList.get(i);
+                CharSequence riLabel = ri.loadLabel(packageManager);
+                if (riLabel == null) {
+                    riLabel = ri.activityInfo.packageName;
+                }
+                if (riLabel.equals(r0Label)) {
+                    continue;
+                }
+                processGroup(resolved, currentResolveList, start, (i - 1), r0, r0Label);
+                r0 = ri;
+                r0Label = riLabel;
+                start = i;
+            }
+            // Process last group
+            processGroup(resolved, currentResolveList, start, (N - 1), r0, r0Label);
+        }
+        return resolved;
+    }
+
+    private static void removePackageFromList(final String packageName, List<ResolveInfo> currentResolveList) {
+        List<ResolveInfo> infosToRemoved = new ArrayList<>();
+        for (ResolveInfo info : currentResolveList) {
+            if (info.activityInfo.packageName.equals(packageName)) {
+                infosToRemoved.add(info);
+            }
+        }
+        currentResolveList.removeAll(infosToRemoved);
+    }
+
+    private void addBrowsersToList(List<ResolveInfo> currentResolveList, int flag) {
+        final int initialSize = currentResolveList.size();
+
+        List<ResolveInfo> browsers = queryBrowserIntentActivities(flag);
+        for (ResolveInfo browser : browsers) {
+            boolean browserFound = false;
+
+            for (int i = 0; i < initialSize; i++) {
+                ResolveInfo info = currentResolveList.get(i);
+
+                if (info.activityInfo.packageName.equals(browser.activityInfo.packageName)) {
+                    browserFound = true;
+                    break;
+                }
+            }
+
+            if (!browserFound) {
+                currentResolveList.add(browser);
+            }
+        }
+    }
+
+    private List<ResolveInfo> queryBrowserIntentActivities(int flags) {
+        return packageManager.queryIntentActivities(BROWSER_INTENT, flags);
+    }
+
+    private void processGroup(
+            List<DisplayResolveInfo> resolved,
+            List<ResolveInfo> rList, int start, int end, ResolveInfo ro,
+                              CharSequence roLabel) {
+        // Process labels from start to i
+        int num = end - start + 1;
+        if (num == 1) {
+            // No duplicate labels. Use label for entry at start
+            resolved.add(new DisplayResolveInfo(ro, roLabel, null));
+            updateLastChosenPosition(resolved, ro);
+        } else {
+            mShowExtended = true;
+            boolean usePkg = false;
+            CharSequence startApp = ro.activityInfo.applicationInfo.loadLabel(packageManager);
+            if (startApp == null) {
+                usePkg = true;
+            }
+            if (!usePkg) {
+                // Use HashSet to track duplicates
+                HashSet<CharSequence> duplicates =
+                        new HashSet<>();
+                duplicates.add(startApp);
+                for (int j = start + 1; j <= end; j++) {
+                    ResolveInfo jRi = rList.get(j);
+                    CharSequence jApp = jRi.activityInfo.applicationInfo.loadLabel(packageManager);
+                    if ((jApp == null) || (duplicates.contains(jApp))) {
+                        usePkg = true;
+                        break;
+                    } else {
+                        duplicates.add(jApp);
+                    }
+                }
+                // Clear HashSet for later use
+                duplicates.clear();
+            }
+            for (int k = start; k <= end; k++) {
+                ResolveInfo add = rList.get(k);
+                if (usePkg) {
+                    // Use application name for all entries from start to end-1
+                    resolved.add(new DisplayResolveInfo(add, roLabel,
+                                                          add.activityInfo.packageName
+                    ));
+                } else {
+                    // Use package name for all entries from start to end-1
+                    resolved.add(new DisplayResolveInfo(add, roLabel,
+                                                          add.activityInfo.applicationInfo.loadLabel(packageManager)
+                    ));
+                }
+                updateLastChosenPosition(resolved, add);
+            }
+        }
+    }
+
+    private void updateLastChosenPosition(List<DisplayResolveInfo> resolved, ResolveInfo info) {
+        if (lastChosenComponent != null
+                && lastChosenComponent.getPackageName().equals(info.activityInfo.packageName)
+                && lastChosenComponent.getClassName().equals(info.activityInfo.name)) {
+            lastChosenPosition = resolved.size() - 1;
+        }
+    }
+}

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolveListAdapter.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolveListAdapter.java
@@ -4,14 +4,9 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.support.annotation.Nullable;
-import android.support.v4.app.ShareCompat;
 import android.support.v7.widget.RecyclerView;
-import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,47 +16,26 @@ import android.widget.TextView;
 import com.tasomaniac.openwith.IconLoader;
 import com.tasomaniac.openwith.R;
 
-import javax.inject.Inject;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import dagger.Lazy;
 
-import static android.os.Build.VERSION.SDK_INT;
-import static android.os.Build.VERSION_CODES.M;
-import static com.tasomaniac.openwith.resolver.ResolverActivity.EXTRA_LAST_CHOSEN_COMPONENT;
-
 public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.ViewHolder> {
 
     private static final int TYPE_ITEM = 2;
     private static final int TYPE_HEADER = 1;
-    private static final Intent BROWSER_INTENT;
 
-    static {
-        BROWSER_INTENT = new Intent();
-        BROWSER_INTENT.setAction(Intent.ACTION_VIEW);
-        BROWSER_INTENT.addCategory(Intent.CATEGORY_BROWSABLE);
-        BROWSER_INTENT.setData(Uri.parse("http:"));
-    }
-
-    private final PackageManager packageManager;
-    private final Lazy<ResolverComparator> resolverComparator;
     private final IconLoader iconLoader;
     private final Intent sourceIntent;
-    private final String callerPackage;
-    private final ComponentName lastChosenComponent;
-    private final boolean mFilterLastUsed;
+    private final IntentResolver intentResolver;
 
     protected final List<DisplayResolveInfo> mList = new ArrayList<>();
 
-    protected boolean mShowExtended;
     private boolean hasHeader;
     private boolean selectionEnabled;
-    private int lastChosenPosition = RecyclerView.NO_POSITION;
     private int checkedItemPosition = RecyclerView.NO_POSITION;
 
     private ItemClickListener itemClickListener;
@@ -76,218 +50,37 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
         }, iconLoader, null);
     }
 
-    @Inject
     public ResolveListAdapter(Context context,
                               Lazy<ResolverComparator> resolverComparator,
                               IconLoader iconLoader,
                               Intent intent) {
-        this.packageManager = context.getPackageManager();
-        this.resolverComparator = resolverComparator;
         this.iconLoader = iconLoader;
         this.sourceIntent = intent;
 
         if (sourceIntent != null) {
-            callerPackage = sourceIntent.getStringExtra(ShareCompat.EXTRA_CALLING_PACKAGE);
-            lastChosenComponent = sourceIntent.getParcelableExtra(EXTRA_LAST_CHOSEN_COMPONENT);
-            mFilterLastUsed = true;
-            rebuildList(sourceIntent);
+            intentResolver = new IntentResolver(context.getPackageManager(), resolverComparator, sourceIntent);
+            mList.addAll(intentResolver.rebuildList());
         } else {
-            callerPackage = null;
-            lastChosenComponent = null;
-            mFilterLastUsed = false;
+            intentResolver = null;
         }
     }
 
     void handlePackagesChanged() {
-        rebuildList(sourceIntent);
+        mList.clear();
+        mList.addAll(intentResolver.rebuildList());
         notifyDataSetChanged();
     }
 
     DisplayResolveInfo getFilteredItem() {
-        if (mFilterLastUsed && lastChosenPosition >= 0) {
+        if (shouldFilterLastUsed() && lastChosenPosition() >= 0) {
             // Not using getItem since it offsets to dodge this position for the list
-            return mList.get(lastChosenPosition);
+            return mList.get(lastChosenPosition());
         }
         return null;
     }
 
     boolean hasFilteredItem() {
-        return mFilterLastUsed && lastChosenPosition >= 0;
-    }
-
-    private void rebuildList(Intent intent) {
-        mList.clear();
-        int flag;
-        if (SDK_INT >= M) {
-            flag = PackageManager.MATCH_ALL;
-        } else {
-            flag = PackageManager.MATCH_DEFAULT_ONLY;
-        }
-        flag = flag | (mFilterLastUsed ? PackageManager.GET_RESOLVED_FILTER : 0);
-
-        List<ResolveInfo> currentResolveList = new ArrayList<>();
-        currentResolveList.addAll(packageManager.queryIntentActivities(intent, flag));
-
-        if (SDK_INT >= M) {
-            addBrowsersToList(currentResolveList, flag);
-        }
-
-        //Remove the components from the caller
-        if (!TextUtils.isEmpty(callerPackage)) {
-            removePackageFromList(callerPackage, currentResolveList);
-        }
-
-        int N;
-        if ((N = currentResolveList.size()) > 0) {
-            // Only display the first matches that are either of equal
-            // priority or have asked to be default options.
-            ResolveInfo r0 = currentResolveList.get(0);
-            for (int i = 1; i < N; i++) {
-                ResolveInfo ri = currentResolveList.get(i);
-
-                if (r0.priority != ri.priority ||
-                        r0.isDefault != ri.isDefault) {
-                    while (i < N) {
-                        currentResolveList.remove(i);
-                        N--;
-                    }
-                }
-            }
-
-            //If there is no left, return
-            if (N <= 0) {
-                return;
-            }
-
-            if (N > 1) {
-                Collections.sort(currentResolveList, resolverComparator.get());
-            }
-
-            // Check for applications with same name and use application name or
-            // package name if necessary
-            r0 = currentResolveList.get(0);
-            int start = 0;
-            CharSequence r0Label = r0.loadLabel(packageManager);
-            mShowExtended = false;
-            for (int i = 1; i < N; i++) {
-                if (r0Label == null) {
-                    r0Label = r0.activityInfo.packageName;
-                }
-                ResolveInfo ri = currentResolveList.get(i);
-                CharSequence riLabel = ri.loadLabel(packageManager);
-                if (riLabel == null) {
-                    riLabel = ri.activityInfo.packageName;
-                }
-                if (riLabel.equals(r0Label)) {
-                    continue;
-                }
-                processGroup(currentResolveList, start, (i - 1), r0, r0Label);
-                r0 = ri;
-                r0Label = riLabel;
-                start = i;
-            }
-            // Process last group
-            processGroup(currentResolveList, start, (N - 1), r0, r0Label);
-        }
-    }
-
-    private static void removePackageFromList(final String packageName, List<ResolveInfo> currentResolveList) {
-        List<ResolveInfo> infosToRemoved = new ArrayList<>();
-        for (ResolveInfo info : currentResolveList) {
-            if (info.activityInfo.packageName.equals(packageName)) {
-                infosToRemoved.add(info);
-            }
-        }
-        currentResolveList.removeAll(infosToRemoved);
-    }
-
-    private void addBrowsersToList(List<ResolveInfo> currentResolveList, int flag) {
-        final int initialSize = currentResolveList.size();
-
-        List<ResolveInfo> browsers = queryBrowserIntentActivities(flag);
-        for (ResolveInfo browser : browsers) {
-            boolean browserFound = false;
-
-            for (int i = 0; i < initialSize; i++) {
-                ResolveInfo info = currentResolveList.get(i);
-
-                if (info.activityInfo.packageName.equals(browser.activityInfo.packageName)) {
-                    browserFound = true;
-                    break;
-                }
-            }
-
-            if (!browserFound) {
-                currentResolveList.add(browser);
-            }
-        }
-    }
-
-    private List<ResolveInfo> queryBrowserIntentActivities(int flags) {
-        return packageManager.queryIntentActivities(BROWSER_INTENT, flags);
-    }
-
-    private void processGroup(List<ResolveInfo> rList, int start, int end, ResolveInfo ro,
-                              CharSequence roLabel) {
-        // Process labels from start to i
-        int num = end - start + 1;
-        if (num == 1) {
-            // No duplicate labels. Use label for entry at start
-            addResolveInfo(new DisplayResolveInfo(ro, roLabel, null));
-            updateLastChosenPosition(ro);
-        } else {
-            mShowExtended = true;
-            boolean usePkg = false;
-            CharSequence startApp = ro.activityInfo.applicationInfo.loadLabel(packageManager);
-            if (startApp == null) {
-                usePkg = true;
-            }
-            if (!usePkg) {
-                // Use HashSet to track duplicates
-                HashSet<CharSequence> duplicates =
-                        new HashSet<>();
-                duplicates.add(startApp);
-                for (int j = start + 1; j <= end; j++) {
-                    ResolveInfo jRi = rList.get(j);
-                    CharSequence jApp = jRi.activityInfo.applicationInfo.loadLabel(packageManager);
-                    if ((jApp == null) || (duplicates.contains(jApp))) {
-                        usePkg = true;
-                        break;
-                    } else {
-                        duplicates.add(jApp);
-                    }
-                }
-                // Clear HashSet for later use
-                duplicates.clear();
-            }
-            for (int k = start; k <= end; k++) {
-                ResolveInfo add = rList.get(k);
-                if (usePkg) {
-                    // Use application name for all entries from start to end-1
-                    addResolveInfo(new DisplayResolveInfo(add, roLabel,
-                                                          add.activityInfo.packageName
-                    ));
-                } else {
-                    // Use package name for all entries from start to end-1
-                    addResolveInfo(new DisplayResolveInfo(add, roLabel,
-                                                          add.activityInfo.applicationInfo.loadLabel(packageManager)
-                    ));
-                }
-                updateLastChosenPosition(add);
-            }
-        }
-    }
-
-    private void updateLastChosenPosition(ResolveInfo info) {
-        if (lastChosenComponent != null
-                && lastChosenComponent.getPackageName().equals(info.activityInfo.packageName)
-                && lastChosenComponent.getClassName().equals(info.activityInfo.name)) {
-            lastChosenPosition = mList.size() - 1;
-        }
-    }
-
-    private void addResolveInfo(DisplayResolveInfo dri) {
-        mList.add(dri);
+        return shouldFilterLastUsed() && lastChosenPosition() >= 0;
     }
 
     DisplayResolveInfo displayResolveInfoForPosition(int position, boolean filtered) {
@@ -297,7 +90,7 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
     @Override
     public int getItemCount() {
         int result = mList.size();
-        if (mFilterLastUsed && lastChosenPosition >= 0) {
+        if (shouldFilterLastUsed() && lastChosenPosition() >= 0) {
             result--;
         }
         result += getHeadersCount();
@@ -309,10 +102,14 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
         if (position < 0) {
             position = 0;
         }
-        if (mFilterLastUsed && lastChosenPosition >= 0 && position >= lastChosenPosition) {
+        if (shouldFilterLastUsed() && lastChosenPosition() >= 0 && position >= lastChosenPosition()) {
             position++;
         }
         return mList.get(position);
+    }
+
+    private int lastChosenPosition() {
+        return intentResolver != null ? intentResolver.lastChosenPosition() : RecyclerView.NO_POSITION;
     }
 
     @Override
@@ -377,7 +174,7 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
 
         holder.text.setText(info.displayLabel());
         if (holder.text2 != null) {
-            if (mShowExtended) {
+            if (shouldShowExtended()) {
                 holder.text2.setVisibility(View.VISIBLE);
                 holder.text2.setText(info.extendedInfo());
             } else {
@@ -407,6 +204,14 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
                         && itemLongClickListener.onItemLongClick(v, holder.getAdapterPosition(), holder.getItemId());
             }
         });
+    }
+
+    protected boolean shouldShowExtended() {
+        return intentResolver != null && intentResolver.shouldShowExtended();
+    }
+
+    private boolean shouldFilterLastUsed() {
+        return intentResolver != null;
     }
 
     public void setItemClickListener(@Nullable ItemClickListener itemClickListener) {

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolveListAdapter.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolveListAdapter.java
@@ -62,7 +62,7 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
     }
 
     DisplayResolveInfo getFilteredItem() {
-        if (shouldFilterLastUsed() && lastChosenPosition() >= 0) {
+        if (hasFilteredItem()) {
             // Not using getItem since it offsets to dodge this position for the list
             return mList.get(lastChosenPosition());
         }
@@ -70,7 +70,7 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
     }
 
     boolean hasFilteredItem() {
-        return shouldFilterLastUsed() && lastChosenPosition() >= 0;
+        return lastChosenPosition() >= 0;
     }
 
     DisplayResolveInfo displayResolveInfoForPosition(int position, boolean filtered) {
@@ -80,7 +80,7 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
     @Override
     public int getItemCount() {
         int result = mList.size();
-        if (shouldFilterLastUsed() && lastChosenPosition() >= 0) {
+        if (hasFilteredItem()) {
             result--;
         }
         result += getHeadersCount();
@@ -92,7 +92,7 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
         if (position < 0) {
             position = 0;
         }
-        if (shouldFilterLastUsed() && lastChosenPosition() >= 0 && position >= lastChosenPosition()) {
+        if (hasFilteredItem() && position >= lastChosenPosition()) {
             position++;
         }
         return mList.get(position);
@@ -196,12 +196,12 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
         });
     }
 
+    /**
+     * When {@code true} a second extended line will be displayed for items in the list.
+     * Default value is false
+     */
     protected boolean shouldShowExtended() {
         return intentResolver != null && intentResolver.shouldShowExtended();
-    }
-
-    private boolean shouldFilterLastUsed() {
-        return intentResolver != null;
     }
 
     public void setItemClickListener(@Nullable ItemClickListener itemClickListener) {

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolveListAdapter.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolveListAdapter.java
@@ -1,7 +1,6 @@
 package com.tasomaniac.openwith.resolver;
 
 import android.content.ComponentName;
-import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.os.AsyncTask;
@@ -21,7 +20,6 @@ import java.util.List;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import dagger.Lazy;
 
 public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.ViewHolder> {
 
@@ -29,8 +27,8 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
     private static final int TYPE_HEADER = 1;
 
     private final IconLoader iconLoader;
-    private final Intent sourceIntent;
     private final IntentResolver intentResolver;
+    private final Intent sourceIntent;
 
     protected final List<DisplayResolveInfo> mList = new ArrayList<>();
 
@@ -41,27 +39,19 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
     private ItemClickListener itemClickListener;
     private ItemLongClickListener itemLongClickListener;
 
-    public ResolveListAdapter(Context context, IconLoader iconLoader) {
-        this(context, new Lazy<ResolverComparator>() {
-            @Override
-            public ResolverComparator get() {
-                return null;
-            }
-        }, iconLoader, null);
+    public ResolveListAdapter(IconLoader iconLoader) {
+        this(iconLoader, null, null);
     }
 
-    public ResolveListAdapter(Context context,
-                              Lazy<ResolverComparator> resolverComparator,
-                              IconLoader iconLoader,
-                              Intent intent) {
+    public ResolveListAdapter(IconLoader iconLoader,
+                              IntentResolver intentResolver,
+                              Intent sourceIntent) {
         this.iconLoader = iconLoader;
-        this.sourceIntent = intent;
+        this.intentResolver = intentResolver;
+        this.sourceIntent = sourceIntent;
 
-        if (sourceIntent != null) {
-            intentResolver = new IntentResolver(context.getPackageManager(), resolverComparator, sourceIntent);
+        if (intentResolver != null) {
             mList.addAll(intentResolver.rebuildList());
-        } else {
-            intentResolver = null;
         }
     }
 

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolveListAdapter.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolveListAdapter.java
@@ -441,10 +441,10 @@ public class ResolveListAdapter extends RecyclerView.Adapter<ResolveListAdapter.
         public TextView text;
         @Nullable
         @BindView(R.id.text2)
-        public TextView text2;
+        TextView text2;
         @Nullable
         @BindView(R.id.icon)
-        public ImageView icon;
+        ImageView icon;
 
         public ViewHolder(View view) {
             super(view);

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverActivity.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverActivity.java
@@ -287,10 +287,9 @@ public class ResolverActivity extends AppCompatActivity implements
 
     @Override
     public void onItemClick(DisplayResolveInfo dri) {
-        final boolean hasValidSelection = true;
         if (mAlwaysUseOption && !dri.equals(lastSelected)) {
-            mAlwaysButton.setEnabled(hasValidSelection);
-            mOnceButton.setEnabled(hasValidSelection);
+            mAlwaysButton.setEnabled(true);
+            mOnceButton.setEnabled(true);
             lastSelected = dri;
         } else {
             startSelected(dri, false);

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverActivity.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverActivity.java
@@ -15,7 +15,6 @@
  */
 package com.tasomaniac.openwith.resolver;
 
-import android.content.ComponentName;
 import android.content.ContentValues;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
@@ -24,7 +23,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.support.annotation.Nullable;
-import android.support.v4.app.ShareCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -58,7 +56,6 @@ public class ResolverActivity extends AppCompatActivity implements
         ItemClickListener,
         ItemLongClickListener {
 
-    public static final String EXTRA_PRIORITY_PACKAGES = "EXTRA_PRIORITY_PACKAGES";
     public static final String EXTRA_ADD_TO_HOME_SCREEN = "EXTRA_ADD_TO_HOME_SCREEN";
     private static final String KEY_CHECKED_POS = "KEY_CHECKED_POS";
     private static final String KEY_CHECKED_ITEM = "KEY_CHECKED_ITEM";
@@ -66,8 +63,8 @@ public class ResolverActivity extends AppCompatActivity implements
 
     @Inject IconLoader iconLoader;
     @Inject ChooserHistory history;
+    @Inject ResolveListAdapter mAdapter;
 
-    private ResolveListAdapter mAdapter;
     private boolean mAlwaysUseOption;
     private boolean isAddToHomeScreen;
 
@@ -104,7 +101,7 @@ public class ResolverActivity extends AppCompatActivity implements
 
         setTheme(R.style.BottomSheet_Light);
         super.onCreate(savedInstanceState);
-        component().inject(this);
+        component(intent).inject(this);
 
         isAddToHomeScreen = intent.getBooleanExtra(EXTRA_ADD_TO_HOME_SCREEN, false);
 
@@ -115,16 +112,6 @@ public class ResolverActivity extends AppCompatActivity implements
 
         mPackageMonitor.register(this, getMainLooper(), false);
         mRegistered = true;
-
-        mAdapter = new ResolveListAdapter(
-                this,
-                history,
-                intent,
-                getIntent().getStringExtra(ShareCompat.EXTRA_CALLING_PACKAGE),
-                intent.<ComponentName>getParcelableExtra(EXTRA_LAST_CHOSEN_COMPONENT),
-                true,
-                intent.getStringArrayExtra(EXTRA_PRIORITY_PACKAGES)
-        );
 
         mAlwaysUseOption = !isAddToHomeScreen && !mAdapter.hasFilteredItem();
 
@@ -193,9 +180,10 @@ public class ResolverActivity extends AppCompatActivity implements
         }
     }
 
-    private ResolverComponent component() {
+    private ResolverComponent component(Intent sourceIntent) {
         return DaggerResolverComponent.builder()
                 .appComponent(Injector.obtain(this))
+                .resolverModule(new ResolverModule(this, sourceIntent))
                 .build();
     }
 

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverActivity.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverActivity.java
@@ -126,14 +126,10 @@ public class ResolverActivity extends AppCompatActivity implements
         }
         if (count == 1 && !isAddToHomeScreen) {
             final DisplayResolveInfo dri = mAdapter.displayResolveInfoForPosition(0, false);
-            Toast.makeText(
-                    this,
-                    getString(
-                            R.string.warning_open_link_with_name,
-                            dri.displayLabel()
-                    ),
-                    Toast.LENGTH_SHORT
-            ).show();
+            Toast.makeText(this, getString(
+                    R.string.warning_open_link_with_name,
+                    dri.displayLabel()
+            ), Toast.LENGTH_SHORT).show();
             Intents.startActivityFixingIntent(this, mAdapter.intentForDisplayResolveInfo(dri));
             mPackageMonitor.unregister();
             mRegistered = false;

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverComparator.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverComparator.java
@@ -1,0 +1,117 @@
+package com.tasomaniac.openwith.resolver;
+
+import android.annotation.TargetApi;
+import android.app.usage.UsageStats;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.os.Build;
+
+import java.text.Collator;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Map;
+
+class ResolverComparator implements Comparator<ResolveInfo> {
+
+    private final PackageManager packageManager;
+    private final ChooserHistory history;
+    private final Map<String, UsageStats> usageStatsMap;
+    private final Map<String, Integer> priorityPackages;
+    private final Collator collator;
+    private final boolean isHttp;
+
+    ResolverComparator(PackageManager packageManager,
+                       ChooserHistory history,
+                       Map<String, UsageStats> usageStatsMap,
+                       Map<String, Integer> priorityPackages,
+                       Intent sourceIntent) {
+        this.packageManager = packageManager;
+        this.history = history;
+        this.usageStatsMap = usageStatsMap;
+        this.priorityPackages = priorityPackages;
+        this.collator = Collator.getInstance(Locale.getDefault());
+        this.isHttp = isHttp(sourceIntent);
+    }
+
+    private static boolean isHttp(Intent sourceIntent) {
+        String scheme = sourceIntent.getScheme();
+        return "http".equals(scheme) || "https".equals(scheme);
+    }
+
+    @Override
+    public int compare(ResolveInfo lhs, ResolveInfo rhs) {
+
+        if (isHttp) {
+            // Special case: we want filters that match URI paths/schemes to be
+            // ordered before others.  This is for the case when opening URIs,
+            // to make native apps go above browsers.
+            final boolean lhsSpecific = isSpecificUriMatch(lhs.match);
+            final boolean rhsSpecific = isSpecificUriMatch(rhs.match);
+            if (lhsSpecific != rhsSpecific) {
+                return lhsSpecific ? -1 : 1;
+            }
+        }
+
+        if (history != null) {
+            int leftCount = history.get(lhs.activityInfo.packageName);
+            int rightCount = history.get(rhs.activityInfo.packageName);
+            if (leftCount != rightCount) {
+                return rightCount - leftCount;
+            }
+        }
+
+        if (priorityPackages != null) {
+            int leftPriority = getPriority(lhs);
+            int rightPriority = getPriority(rhs);
+            if (leftPriority != rightPriority) {
+                return rightPriority - leftPriority;
+            }
+        }
+
+        if (usageStatsMap != null) {
+            final long timeDiff =
+                    getPackageTimeSpent(rhs.activityInfo.packageName) -
+                            getPackageTimeSpent(lhs.activityInfo.packageName);
+
+            if (timeDiff != 0) {
+                return timeDiff > 0 ? 1 : -1;
+            }
+        }
+
+        CharSequence sa = lhs.loadLabel(packageManager);
+        if (sa == null) {
+            sa = lhs.activityInfo.name;
+        }
+        CharSequence sb = rhs.loadLabel(packageManager);
+        if (sb == null) {
+            sb = rhs.activityInfo.name;
+        }
+
+        return collator.compare(sa.toString(), sb.toString());
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private long getPackageTimeSpent(String packageName) {
+        if (usageStatsMap != null) {
+            final UsageStats stats = usageStatsMap.get(packageName);
+            if (stats != null) {
+                return stats.getTotalTimeInForeground();
+            }
+
+        }
+        return 0;
+    }
+
+    private int getPriority(ResolveInfo lhs) {
+        final Integer integer = priorityPackages.get(lhs.activityInfo.packageName);
+        return integer != null ? integer : 0;
+    }
+
+    private static boolean isSpecificUriMatch(int match) {
+        match = match & IntentFilter.MATCH_CATEGORY_MASK;
+        return match >= IntentFilter.MATCH_CATEGORY_HOST
+                && match <= IntentFilter.MATCH_CATEGORY_PATH;
+    }
+}

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverComponent.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverComponent.java
@@ -9,4 +9,6 @@ import dagger.Component;
 @Component(dependencies = AppComponent.class, modules = ResolverModule.class)
 interface ResolverComponent {
     void inject(ResolverActivity activity);
+
+    void inject(ResolveListAdapter adapter);
 }

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverModule.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverModule.java
@@ -41,9 +41,13 @@ class ResolverModule {
     }
 
     @Provides
-    ResolveListAdapter provideResolveListAdapter(Lazy<ResolverComparator> resolverComparator,
-                                                 IconLoader iconLoader) {
-        return new ResolveListAdapter(activity, resolverComparator, iconLoader, sourceIntent);
+    IntentResolver intentResolver(Lazy<ResolverComparator> resolverComparator) {
+        return new IntentResolver(activity.getPackageManager(), resolverComparator, sourceIntent);
+    }
+
+    @Provides
+    ResolveListAdapter provideResolveListAdapter(IconLoader iconLoader, IntentResolver intentResolver) {
+        return new ResolveListAdapter(iconLoader, intentResolver, sourceIntent);
     }
 
     @Provides

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverModule.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverModule.java
@@ -1,19 +1,108 @@
 package com.tasomaniac.openwith.resolver;
 
+import android.app.Activity;
 import android.app.Application;
+import android.app.usage.UsageStats;
+import android.app.usage.UsageStatsManager;
+import android.content.Context;
+import android.content.Intent;
 
+import com.tasomaniac.openwith.IconLoader;
 import com.tasomaniac.openwith.PerActivity;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
 
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
+
 @Module
 class ResolverModule {
+
+    private static final long USAGE_STATS_PERIOD = TimeUnit.DAYS.toMillis(14);
+
+    private final Activity activity;
+    private final Intent sourceIntent;
+
+    ResolverModule(Activity activity, Intent sourceIntent) {
+        this.activity = activity;
+        this.sourceIntent = sourceIntent;
+    }
 
     @Provides
     @PerActivity
     static ChooserHistory provideChooserHistory(Application app) {
         return ChooserHistory.fromSettings(app);
     }
+
+    @Provides
+    ResolveListAdapter provideResolveListAdapter(Lazy<ResolverComparator> resolverComparator,
+                                                 IconLoader iconLoader) {
+        return new ResolveListAdapter(activity, resolverComparator, iconLoader, sourceIntent);
+    }
+
+    @Provides
+    @PerActivity
+    ResolverComparator provideResolverComparator(Application app,
+                                                 ChooserHistory history) {
+        return new ResolverComparator(
+                app.getPackageManager(),
+                history,
+                usageStatsFrom(app),
+                priorityItems(),
+                sourceIntent
+        );
+    }
+
+    private static Map<String, UsageStats> usageStatsFrom(Context context) {
+        if (SDK_INT >= LOLLIPOP_MR1) {
+            UsageStatsManager usageStatsManager = (UsageStatsManager) context.getSystemService(Context.USAGE_STATS_SERVICE);
+
+            final long sinceTime = System.currentTimeMillis() - USAGE_STATS_PERIOD;
+            return usageStatsManager.queryAndAggregateUsageStats(sinceTime, System.currentTimeMillis());
+        } else {
+            return null;
+        }
+    }
+
+    private static Map<String, Integer> priorityItems() {
+        int size = PRIORITY_PACKAGES.length;
+        Map<String, Integer> priorityPackages = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            // position 0 should have highest priority,
+            // starting with 1 for lowest priority.
+            priorityPackages.put(PRIORITY_PACKAGES[i], size - i + 1);
+        }
+        return priorityPackages;
+    }
+
+    private static final String[] PRIORITY_PACKAGES = new String[]{
+            "com.whatsapp",
+            "com.twitter.android",
+            "com.facebook.katana",
+            "com.facebook.orca",
+            "com.google.android.youtube",
+            "com.google.android.gm",
+            "com.google.android.talk",
+            "com.google.android.apps.plus",
+            "com.google.android.apps.photos",
+            "com.pandora.android",
+            "com.instagram.android",
+            "com.linkedin.android",
+            "com.spotify.music",
+            "com.pinterest",
+            "com.medium.reader",
+            "com.ubercab",
+            "com.meetup",
+            "com.tumblr",
+            "com.badoo.mobile",
+            "tv.periscope.android",
+            "com.skype.raider"
+    };
 
 }

--- a/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverModule.java
+++ b/app/src/main/java/com/tasomaniac/openwith/resolver/ResolverModule.java
@@ -52,8 +52,7 @@ class ResolverModule {
 
     @Provides
     @PerActivity
-    ResolverComparator provideResolverComparator(Application app,
-                                                 ChooserHistory history) {
+    ResolverComparator provideResolverComparator(Application app, ChooserHistory history) {
         return new ResolverComparator(
                 app.getPackageManager(),
                 history,


### PR DESCRIPTION
`ResolverActivity` and `ResolveListAdapter` were taken from AOSP (I think Lollipop implementation)

After lots of refactorings, they were both still 400+ lines of code. I wanted to extract some logic into classes to make it easier to add features. 

`ResolverComparator` class was already there. That is just moved to its own class. 
`IntentResolver` is extracted from the Adapter. Given a `sourceIntent`, it returns a sorted list of Applications that responds to the intent. 