### PR TITLE
#83 fix: Avoid drawing ResolverActivity on top of SettingsActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,8 +42,8 @@
     <activity
       android:name=".settings.SettingsActivity"
       android:clearTaskOnLaunch="true"
-      android:launchMode="singleInstance"
-      android:exported="true">
+      android:exported="true"
+      android:launchMode="singleInstance">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
 
@@ -54,14 +54,18 @@
     <activity
       android:name=".preferred.PreferredAppsActivity"
       android:label="@string/title_preferred_apps"
+      android:launchMode="singleInstance"
       android:parentActivityName=".settings.SettingsActivity" />
 
     <activity
       android:name=".browser.PreferredBrowserActivity"
       android:label="@string/browser_title"
+      android:launchMode="singleInstance"
       android:parentActivityName=".settings.SettingsActivity" />
 
-    <activity android:name=".settings.advanced.features.ToggleFeatureActivity" />
+    <activity
+      android:name=".settings.advanced.features.ToggleFeatureActivity"
+      android:launchMode="singleInstance" />
 
     <activity
       android:name=".ShareToOpenWith"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
     <activity
       android:name=".settings.SettingsActivity"
       android:clearTaskOnLaunch="true"
+      android:launchMode="singleInstance"
       android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This PR fixes #83 where the ResolverActivity would draw above an open SettingsActivity