### PR TITLE
Fix German translation especially in tutorial

### DIFF
--- a/intro/src/main/res/values-de/strings.xml
+++ b/intro/src/main/res/values-de/strings.xml
@@ -11,7 +11,7 @@
   <string name="description_tutorial_4"><![CDATA[    <strong>Zum Startbildschirm hinzufügen</strong>, um deine Lieblingslinks direkt mit der passenden App vom Startbildschirm aus zu starten.
   ]]></string>
   <string name="title_tutorial_5">Nutzer zugriff</string>
-  <string name="description_tutorial_5"><![CDATA[    Zugriff auf <strong>Nutzer Zugriff</strong> gewähren und ich werde besser arbeiten. Ich erkenne den Browser, den du benutzt, um entsprechend zu funktionieren.
+  <string name="description_tutorial_5"><![CDATA[    Zugriff auf <strong>Nutzerzugriff</strong> gewähren und ich werde besser arbeiten. Ich erkenne den Browser, den du benutzt, um entsprechend zu funktionieren.
   ]]></string>
   <string name="usage_access_give_access">Zugriff erlauben</string>
   <string name="title_preferred_apps">Bevorzugte Apps</string>

--- a/intro/src/main/res/values-de/strings.xml
+++ b/intro/src/main/res/values-de/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="title_tutorial_0">Willkommen bei Open Link With</string>
-  <string name="description_tutorial_0">Ich komme zur Rettung, wenn du mal in deinem Browser fest steckst.</string>
+  <string name="description_tutorial_0">Ich bin deine Rettung, wenn du mal in deinem Browser feststeckst.</string>
   <string name="title_tutorial_1">Ist es ihnen schon mal passiert?</string>
   <string name="description_tutorial_1">Du klickst ein Kurlink an und landest irgendwie auf einer Seite statt das Video direkt anzuschauen.</string>
   <string name="title_tutorial_2">Teilen Sie es!</string>

--- a/intro/src/main/res/values-de/strings.xml
+++ b/intro/src/main/res/values-de/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="title_tutorial_0">Willkommen bei Open Link With</string>
-  <string name="description_tutorial_0">Ich komme zur rettung, wenn du mal in deinem Browser fest steckst.</string>
+  <string name="description_tutorial_0">Ich komme zur Rettung, wenn du mal in deinem Browser fest steckst.</string>
   <string name="title_tutorial_1">Ist es ihnen schon mal passiert?</string>
-  <string name="description_tutorial_1">Du clickst ein short-link an und landest irrgendwie auf einer Seite statt du das Video direkt dir anschaust.</string>
-  <string name="title_tutorial_2">Teilen sie es!</string>
+  <string name="description_tutorial_1">Du klickst ein Kurlink an und landest irgendwie auf einer Seite statt das Video direkt anzuschauen.</string>
+  <string name="title_tutorial_2">Teilen Sie es!</string>
   <string name="description_tutorial_2">Teil es einfach mit mir, und ich werde für dich die Apps wechseln.</string>
   <string name="description_tutorial_3"><![CDATA[    Wählen Sie <strong>immer öffnen</strong> um einen Link immer mit der spezifischen App zu öffnen.
   ]]></string>

--- a/intro/src/main/res/values-de/strings.xml
+++ b/intro/src/main/res/values-de/strings.xml
@@ -3,7 +3,7 @@
   <string name="title_tutorial_0">Willkommen bei Open Link With</string>
   <string name="description_tutorial_0">Ich bin deine Rettung, wenn du mal in deinem Browser feststeckst.</string>
   <string name="title_tutorial_1">Ist es ihnen schon mal passiert?</string>
-  <string name="description_tutorial_1">Du klickst ein Kurlink an und landest irgendwie auf einer Seite statt das Video direkt anzuschauen.</string>
+  <string name="description_tutorial_1">Du klickst einen Kurzlink an und – anstatt, dass du das Video direkt anschauen kannst – landest du irgendwie auf einer Webseite?</string>
   <string name="title_tutorial_2">Teilen Sie es!</string>
   <string name="description_tutorial_2">Teil es einfach mit mir, und ich werde für dich die Apps wechseln.</string>
   <string name="description_tutorial_3"><![CDATA[    Wählen Sie <strong>immer öffnen</strong> um einen Link immer mit der spezifischen App zu öffnen.

--- a/intro/src/main/res/values-de/strings.xml
+++ b/intro/src/main/res/values-de/strings.xml
@@ -4,14 +4,14 @@
   <string name="description_tutorial_0">Ich bin deine Rettung, wenn du mal in deinem Browser feststeckst.</string>
   <string name="title_tutorial_1">Ist es ihnen schon mal passiert?</string>
   <string name="description_tutorial_1">Du klickst einen Kurzlink an und – anstatt, dass du das Video direkt anschauen kannst – landest du irgendwie auf einer Webseite?</string>
-  <string name="title_tutorial_2">Teilen Sie es!</string>
+  <string name="title_tutorial_2">Teil es!</string>
   <string name="description_tutorial_2">Teil es einfach mit mir, und ich werde für dich die Apps wechseln.</string>
   <string name="description_tutorial_3"><![CDATA[    Wählen Sie <strong>immer öffnen</strong> um einen Link immer mit der spezifischen App zu öffnen.
   ]]></string>
   <string name="description_tutorial_4"><![CDATA[    <strong>Zum Startbildschirm hinzufügen</strong>, um deine Lieblingslinks direkt mit der passenden App vom Startbildschirm aus zu starten.
   ]]></string>
   <string name="title_tutorial_5">Nutzer zugriff</string>
-  <string name="description_tutorial_5"><![CDATA[    Zugriff auf <strong>Nutzer Zugriff</strong> gewähren und ich werde besser arbeiten. Ich erkenne den Browser, den sie benutzen um entsprend zu funktionieren.
+  <string name="description_tutorial_5"><![CDATA[    Zugriff auf <strong>Nutzer Zugriff</strong> gewähren und ich werde besser arbeiten. Ich erkenne den Browser, den du benutzt, um entsprechend zu funktionieren.
   ]]></string>
   <string name="usage_access_give_access">Zugriff erlauben</string>
   <string name="title_preferred_apps">Bevorzugte Apps</string>


### PR DESCRIPTION
The tutorial had some heavy typos/wrong translation in German, fixed here.

Also note yes I've tried Crowdin, but somehow I could not find your (error) string there:
https://crowdin.com/editor/open-link-with/1168/enus-de?view=comfortable&filter=basic&value=0#q=irrgendwie

![grafik](https://github.com/user-attachments/assets/7331c78f-5049-4d4e-ae38-2c7a772ec7a4)

Even knowing and searching for the ID `description_tutorial_1` did not work, so I guess there is something else wrong?
I hope a PR is fine too though.